### PR TITLE
Colors presets

### DIFF
--- a/altair_upset/preprocessing.py
+++ b/altair_upset/preprocessing.py
@@ -39,6 +39,14 @@ def preprocess_data(data, sets, abbre, sort_order):
     data = pd.melt(data, id_vars=["intersection_id", "count", "degree"])
     data = data.rename(columns={"variable": "set", "value": "is_intersect"})
 
+    # Create a column of concurrent groups (future update for better labelling)
+    # sets_mapping = (data.loc[data["is_intersect"] > 0].groupby("intersection_id")["set"]
+    #                 .apply(lambda x: " ".join(sorted(x))).to_dict())
+    #
+    # data["sets_graph"] = data.apply(
+    #     lambda row: row["set"] if row["is_intersect"] == 0 else sets_mapping.get(row["intersection_id"], ""),
+    #     axis=1).fillna("").astype(str)
+
     if abbre is None:
         abbre = sets
 

--- a/altair_upset/upset.py
+++ b/altair_upset/upset.py
@@ -89,7 +89,6 @@ def UpSetAltair(
     line_connection_size: int = 1,  # Reduced from 2
     horizontal_bar_size: int = 20,
     vertical_bar_label_size: int = 16,
-    vertical_bar_padding: int = 20,
     theme: Optional[str] = None,
 ) -> UpSetChart:
     """Generate interactive UpSet plots using Altair. [Lex et al., 2014]_
@@ -138,8 +137,6 @@ def UpSetAltair(
         Height of horizontal bars in pixels.
     vertical_bar_label_size : int, default 16
         Font size of vertical bar labels.
-    vertical_bar_padding : int, default 20
-        Padding between vertical bars.
     theme : str, optional
         Altair theme to use. If None, uses the current default theme.
 
@@ -214,10 +211,10 @@ def UpSetAltair(
     vertical_bar_chart_height = height * height_ratio
     matrix_height = (height - vertical_bar_chart_height) * 0.8  # Reduce height to tighten spacing
     matrix_width = width - horizontal_bar_chart_width
-    vertical_bar_size = min(
-        30,
-        width / len(data["intersection_id"].unique().tolist()) - vertical_bar_padding,
-    )
+
+    # Automatic padding
+    num_intersections = max(1, len(data["intersection_id"].unique().tolist()))
+    vertical_bar_size = min(30, (matrix_width / num_intersections) - 5)  # 5 is good
 
     # Setup styles
     main_color = "#3A3A3A"
@@ -232,9 +229,9 @@ def UpSetAltair(
         field="count" if sort_by == "frequency" else "degree", order=sort_order
     )
     tooltip = [
-        alt.Tooltip("max(count):Q", title="Cardinality"),
+        alt.Tooltip("count:Q", title="Cardinality"),
         alt.Tooltip("degree:Q", title="Degree"),
-        alt.Tooltip("sets:N", title="Sets"),
+        # alt.Tooltip("sets_graph:N", title="Groups"),  # Bugged. sets_graph is already available in preprocessing.py
     ]
 
     # Create base chart
@@ -299,7 +296,7 @@ def UpSetAltair(
             horizontal_bar_axis,
             horizontal_bar.properties(width=horizontal_bar_chart_width),
             spacing=0,  # Minimize spacing between components
-        ).resolve_scale(y="shared"),
+        ).resolve_scale(x="shared", y="shared"),  # X shared also
         spacing=5,
     ).add_params(legend_selection)
 

--- a/altair_upset/upset.py
+++ b/altair_upset/upset.py
@@ -2,11 +2,71 @@ from typing import List, Optional, Union
 
 import altair as alt
 import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 from .components import create_horizontal_bar, create_matrix_view, create_vertical_bar
 from .config import upsetaltair_top_level_configuration
 from .preprocessing import preprocess_data
 from .transforms import create_base_chart
+
+colors_range_presets = ['Accent', 'Accent_r', 'Blues', 'Blues_r', 'BrBG', 'BrBG_r', 'BuGn', 'BuGn_r', 'BuPu', 'BuPu_r',
+                        'CMRmap', 'CMRmap_r', 'Dark2', 'Dark2_r', 'GnBu', 'GnBu_r', 'Grays', 'Grays_r', 'Greens',
+                        'Greens_r',
+                        'Greys', 'Greys_r', 'OrRd', 'OrRd_r', 'Oranges', 'Oranges_r', 'PRGn', 'PRGn_r', 'Paired',
+                        'Paired_r',
+                        'Pastel1', 'Pastel1_r', 'Pastel2', 'Pastel2_r', 'PiYG', 'PiYG_r', 'PuBu', 'PuBuGn', 'PuBuGn_r',
+                        'PuBu_r', 'PuOr', 'PuOr_r', 'PuRd', 'PuRd_r', 'Purples', 'Purples_r', 'RdBu', 'RdBu_r', 'RdGy',
+                        'RdGy_r', 'RdPu', 'RdPu_r', 'RdYlBu', 'RdYlBu_r', 'RdYlGn', 'RdYlGn_r', 'Reds', 'Reds_r',
+                        'Set1',
+                        'Set1_r', 'Set2', 'Set2_r', 'Set3', 'Set3_r', 'Spectral', 'Spectral_r', 'Wistia', 'Wistia_r',
+                        'YlGn',
+                        'YlGnBu', 'YlGnBu_r', 'YlGn_r', 'YlOrBr', 'YlOrBr_r', 'YlOrRd', 'YlOrRd_r', 'afmhot',
+                        'afmhot_r',
+                        'autumn', 'autumn_r', 'berlin', 'berlin_r', 'binary', 'binary_r', 'bone', 'bone_r', 'brg',
+                        'brg_r',
+                        'bwr', 'bwr_r', 'cividis', 'cividis_r', 'cool', 'cool_r', 'coolwarm', 'coolwarm_r', 'copper',
+                        'copper_r', 'cubehelix', 'cubehelix_r', 'flag', 'flag_r', 'gist_earth', 'gist_earth_r',
+                        'gist_gray',
+                        'gist_gray_r', 'gist_grey', 'gist_grey_r', 'gist_heat', 'gist_heat_r', 'gist_ncar',
+                        'gist_ncar_r',
+                        'gist_rainbow', 'gist_rainbow_r', 'gist_stern', 'gist_stern_r', 'gist_yarg', 'gist_yarg_r',
+                        'gist_yerg', 'gist_yerg_r', 'gnuplot', 'gnuplot2', 'gnuplot2_r', 'gnuplot_r', 'gray', 'gray_r',
+                        'grey', 'grey_r', 'hot', 'hot_r', 'hsv', 'hsv_r', 'inferno', 'inferno_r', 'jet', 'jet_r',
+                        'magma',
+                        'magma_r', 'managua', 'managua_r', 'nipy_spectral', 'nipy_spectral_r', 'ocean', 'ocean_r',
+                        'pink',
+                        'pink_r', 'plasma', 'plasma_r', 'prism', 'prism_r', 'rainbow', 'rainbow_r', 'seismic',
+                        'seismic_r',
+                        'spring', 'spring_r', 'summer', 'summer_r', 'tab10', 'tab10_r', 'tab20', 'tab20_r', 'tab20b',
+                        'tab20b_r', 'tab20c', 'tab20c_r', 'terrain', 'terrain_r', 'turbo', 'turbo_r', 'twilight',
+                        'twilight_r', 'twilight_shifted', 'twilight_shifted_r', 'vanimo', 'vanimo_r', 'viridis',
+                        'viridis_r',
+                        'winter', 'winter_r']
+
+colors_highlight_presets = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black',
+                            'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse',
+                            'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue',
+                            'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki',
+                            'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon',
+                            'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise',
+                            'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick',
+                            'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod',
+                            'gray', 'green', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo',
+                            'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue',
+                            'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey',
+                            'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray',
+                            'lightslategrey', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta',
+                            'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple',
+                            'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise',
+                            'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite',
+                            'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod',
+                            'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink',
+                            'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue',
+                            'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver',
+                            'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue',
+                            'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke',
+                            'yellow', 'yellowgreen']
 
 
 class UpSetChart:
@@ -63,33 +123,33 @@ class UpSetChart:
 
 
 def UpSetAltair(
-    data: pd.DataFrame,
-    sets: List[str],
-    *,
-    title: str = "",
-    subtitle: Union[str, List[str]] = "",
-    abbre: Optional[List[str]] = None,
-    sort_by: str = "frequency",
-    sort_order: str = "ascending",
-    width: int = 1200,
-    height: int = 700,
-    height_ratio: float = 0.6,
-    horizontal_bar_chart_width: Optional[int] = None,
-    color_range: List[str] = [
-        "#55A8DB",
-        "#3070B5",
-        "#30363F",
-        "#F1AD60",
-        "#DF6234",
-        "#BDC6CA",
-    ],
-    highlight_color: str = "#EA4667",
-    glyph_size: int = 100,  # Reduced from 200
-    set_label_bg_size: int = 500,  # Reduced from 1000
-    line_connection_size: int = 1,  # Reduced from 2
-    horizontal_bar_size: int = 20,
-    vertical_bar_label_size: int = 16,
-    theme: Optional[str] = None,
+        data: pd.DataFrame,
+        sets: List[str],
+        *,
+        title: str = "",
+        subtitle: Union[str, List[str]] = "",
+        abbre: Optional[List[str]] = None,
+        sort_by: str = "frequency",
+        sort_order: str = "ascending",
+        width: int = 1200,
+        height: int = 700,
+        height_ratio: float = 0.6,
+        horizontal_bar_chart_width: Optional[int] = None,
+        color_range: Union[str, List[str]] = [
+            "#55A8DB",
+            "#3070B5",
+            "#30363F",
+            "#F1AD60",
+            "#DF6234",
+            "#BDC6CA",
+        ],
+        highlight_color: str = "#EA4667",
+        glyph_size: int = 100,  # Reduced from 200
+        set_label_bg_size: int = 500,  # Reduced from 1000
+        line_connection_size: int = 1,  # Reduced from 2
+        horizontal_bar_size: int = 20,
+        vertical_bar_label_size: int = 16,
+        theme: Optional[str] = None,
 ) -> UpSetChart:
     """Generate interactive UpSet plots using Altair. [Lex et al., 2014]_
 
@@ -123,9 +183,338 @@ def UpSetAltair(
         Ratio of vertical bar chart height to total height (between 0 and 1).
     horizontal_bar_chart_width : int, default 300
         Width of the horizontal bar chart in pixels.
-    color_range : list of str
+    color_range : str or list of str
+        List of presets accepted in str:
+        - 'Accent'
+        - 'Accent_r''Blues'
+        - 'Blues_r'
+        - 'BrBG'
+        - 'BrBG_r'
+        - 'BuGn'
+        - 'BuGn_r'
+        - 'BuPu'
+        - 'BuPu_r'
+        - 'CMRmap'
+        - 'CMRmap_r'
+        - 'Dark2'
+        - 'Dark2_r'
+        - 'GnBu'
+        - 'GnBu_r'
+        - 'Grays'
+        - 'Grays_r'
+        - 'Greens'
+        - 'Greens_r'
+        - 'Greys'
+        - 'Greys_r'
+        - 'OrRd'
+        - 'OrRd_r'
+        - 'Oranges'
+        - 'Oranges_r'
+        - 'PRGn'
+        - 'PRGn_r'
+        - 'Paired'
+        - 'Paired_r'
+        - 'Pastel1'
+        - 'Pastel1_r'
+        - 'Pastel2'
+        - 'Pastel2_r'
+        - 'PiYG'
+        - 'PiYG_r'
+        - 'PuBu'
+        - 'PuBuGn'
+        - 'PuBuGn_r'
+        - 'PuBu_r'
+        - 'PuOr'
+        - 'PuOr_r'
+        - 'PuRd'
+        - 'PuRd_r'
+        - 'Purples'
+        - 'Purples_r'
+        - 'RdBu'
+        - 'RdBu_r'
+        - 'RdGy'
+        - 'RdGy_r'
+        - 'RdPu'
+        - 'RdPu_r'
+        - 'RdYlBu'
+        - 'RdYlBu_r'
+        - 'RdYlGn'
+        - 'RdYlGn_r'
+        - 'Reds'
+        - 'Reds_r'
+        - 'Set1'
+        - 'Set1_r'
+        - 'Set2'
+        - 'Set2_r'
+        - 'Set3'
+        - 'Set3_r'
+        - 'Spectral'
+        - 'Spectral_r'
+        - 'Wistia'
+        - 'Wistia_r'
+        - 'YlGn'
+        - 'YlGnBu'
+        - 'YlGnBu_r'
+        - 'YlGn_r'
+        - 'YlOrBr'
+        - 'YlOrBr_r'
+        - 'YlOrRd'
+        - 'YlOrRd_r'
+        - 'afmhot'
+        - 'afmhot_r'
+        - 'autumn'
+        - 'autumn_r'
+        - 'berlin'
+        - 'berlin_r'
+        - 'binary'
+        - 'binary_r'
+        - 'bone'
+        - 'bone_r'
+        - 'brg'
+        - 'brg_r'
+        - 'bwr'
+        - 'bwr_r'
+        - 'cividis'
+        - 'cividis_r'
+        - 'cool'
+        - 'cool_r'
+        - 'coolwarm'
+        - 'coolwarm_r'
+        - 'copper'
+        - 'copper_r'
+        - 'cubehelix'
+        - 'cubehelix_r'
+        - 'flag'
+        - 'flag_r'
+        - 'gist_earth'
+        - 'gist_earth_r'
+        - 'gist_gray'
+        - 'gist_gray_r'
+        - 'gist_grey'
+        - 'gist_grey_r'
+        - 'gist_heat'
+        - 'gist_heat_r'
+        - 'gist_ncar'
+        - 'gist_ncar_r'
+        - 'gist_rainbow'
+        - 'gist_rainbow_r'
+        - 'gist_stern'
+        - 'gist_stern_r'
+        - 'gist_yarg'
+        - 'gist_yarg_r'
+        - 'gist_yerg'
+        - 'gist_yerg_r'
+        - 'gnuplot'
+        - 'gnuplot2'
+        - 'gnuplot2_r'
+        - 'gnuplot_r'
+        - 'gray'
+        - 'gray_r'
+        - 'grey'
+        - 'grey_r'
+        - 'hot'
+        - 'hot_r'
+        - 'hsv'
+        - 'hsv_r'
+        - 'inferno'
+        - 'inferno_r'
+        - 'jet'
+        - 'jet_r'
+        - 'magma'
+        - 'magma_r'
+        - 'managua'
+        - 'managua_r'
+        - 'nipy_spectral'
+        - 'nipy_spectral_r'
+        - 'ocean'
+        - 'ocean_r'
+        - 'pink'
+        - 'pink_r'
+        - 'plasma'
+        - 'plasma_r'
+        - 'prism'
+        - 'prism_r'
+        - 'rainbow'
+        - 'rainbow_r'
+        - 'seismic'
+        - 'seismic_r'
+        - 'spring'
+        - 'spring_r'
+        - 'summer'
+        - 'summer_r'
+        - 'tab10'
+        - 'tab10_r'
+        - 'tab20'
+        - 'tab20_r'
+        - 'tab20b'
+        - 'tab20b_r'
+        - 'tab20c'
+        - 'tab20c_r'
+        - 'terrain'
+        - 'terrain_r'
+        - 'turbo'
+        - 'turbo_r'
+        - 'twilight'
+        - 'twilight_r'
+        - 'twilight_shifted'
+        - 'twilight_shifted_r'
+        - 'vanimo'
+        - 'vanimo_r'
+        - 'viridis'
+        - 'viridis_r'
+        - 'winter'
+        - 'winter_r'
         List of colors for the sets. Defaults to a colorblind-friendly palette.
     highlight_color : str, default "#EA4667"
+        List of presets accepted:
+        - aliceblue'
+        - 'antiquewhite'
+        - 'aqua'
+        - 'aquamarine'
+        - 'azure'
+        - 'beige'
+        - 'bisque'
+        - 'black'
+        - 'blanchedalmond'
+        - 'blue'
+        - 'blueviolet'
+        - 'brown'
+        - 'burlywood'
+        - 'cadetblue'
+        - 'chartreuse'
+        - 'chocolate'
+        - 'coral'
+        - 'cornflowerblue'
+        - 'cornsilk'
+        - 'crimson'
+        - 'cyan'
+        - 'darkblue'
+        - 'darkcyan'
+        - 'darkgoldenrod'
+        - 'darkgray'
+        - 'darkgreen'
+        - 'darkgrey'
+        - 'darkkhaki'
+        - 'darkmagenta'
+        - 'darkolivegreen'
+        - 'darkorange'
+        - 'darkorchid'
+        - 'darkred'
+        - 'darksalmon'
+        - 'darkseagreen'
+        - 'darkslateblue'
+        - 'darkslategray'
+        - 'darkslategrey'
+        - 'darkturquoise'
+        - 'darkviolet'
+        - 'deeppink'
+        - 'deepskyblue'
+        - 'dimgray'
+        - 'dimgrey'
+        - 'dodgerblue'
+        - 'firebrick'
+        - 'floralwhite'
+        - 'forestgreen'
+        - 'fuchsia'
+        - 'gainsboro'
+        - 'ghostwhite'
+        - 'gold'
+        - 'goldenrod'
+        - 'gray'
+        - 'green'
+        - 'greenyellow'
+        - 'grey'
+        - 'honeydew'
+        - 'hotpink'
+        - 'indianred'
+        - 'indigo'
+        - 'ivory'
+        - 'khaki'
+        - 'lavender'
+        - 'lavenderblush'
+        - 'lawngreen'
+        - 'lemonchiffon'
+        - 'lightblue'
+        - 'lightcoral'
+        - 'lightcyan'
+        - 'lightgoldenrodyellow'
+        - 'lightgray'
+        - 'lightgreen'
+        - 'lightgrey'
+        - 'lightpink'
+        - 'lightsalmon'
+        - 'lightseagreen'
+        - 'lightskyblue'
+        - 'lightslategray'
+        - 'lightslategrey'
+        - 'lightsteelblue'
+        - 'lightyellow'
+        - 'lime'
+        - 'limegreen'
+        - 'linen'
+        - 'magenta'
+        - 'maroon'
+        - 'mediumaquamarine'
+        - 'mediumblue'
+        - 'mediumorchid'
+        - 'mediumpurple'
+        - 'mediumseagreen'
+        - 'mediumslateblue'
+        - 'mediumspringgreen'
+        - 'mediumturquoise'
+        - 'mediumvioletred'
+        - 'midnightblue'
+        - 'mintcream'
+        - 'mistyrose'
+        - 'moccasin'
+        - 'navajowhite'
+        - 'navy'
+        - 'oldlace'
+        - 'olive'
+        - 'olivedrab'
+        - 'orange'
+        - 'orangered'
+        - 'orchid'
+        - 'palegoldenrod'
+        - 'palegreen'
+        - 'paleturquoise'
+        - 'palevioletred'
+        - 'papayawhip'
+        - 'peachpuff'
+        - 'peru'
+        - 'pink'
+        - 'plum'
+        - 'powderblue'
+        - 'purple'
+        - 'rebeccapurple'
+        - 'red'
+        - 'rosybrown'
+        - 'royalblue'
+        - 'saddlebrown'
+        - 'salmon'
+        - 'sandybrown'
+        - 'seagreen'
+        - 'seashell'
+        - 'sienna'
+        - 'silver'
+        - 'skyblue'
+        - 'slateblue'
+        - 'slategray'
+        - 'slategrey'
+        - 'snow'
+        - 'springgreen'
+        - 'steelblue'
+        - 'tan'
+        - 'teal'
+        - 'thistle'
+        - 'tomato'
+        - 'turquoise'
+        - 'violet'
+        - 'wheat'
+        - 'white'
+        - 'whitesmoke'
+        - 'yellow'
+        - 'yellowgreen'
         Color used for highlighting on hover.
     glyph_size : int, default 200
         Size of the matrix glyphs in pixels.
@@ -190,6 +579,23 @@ def UpSetAltair(
         raise ValueError("sort_order must be either 'ascending' or 'descending'")
     if abbre is not None and len(sets) != len(abbre):
         raise ValueError("if provided, abbre must have the same length as sets")
+
+    # Colors range presets
+    if isinstance(color_range, str):
+        try:
+            cmap = plt.get_cmap(color_range)
+            color_range = [mcolors.to_hex(cmap(i / (len(sets) - 1))) for i in range(len(sets))]
+        except ValueError:
+            print(ValueError("color_range must be one of {}".format(colors_range_presets)))
+            color_range = ["#55A8DB", "#3070B5", "#30363F", "#F1AD60", "#DF6234", "#BDC6CA"]
+
+    # Colors highlight presets
+    if not highlight_color.startswith("#"):
+        try:
+            mcolors.to_hex(mcolors.CSS4_COLORS.get(highlight_color, highlight_color))
+        except ValueError:
+            print(ValueError("highlight_color must be one of {}".format(colors_highlight_presets)))
+            highlight_color = "#EA4667"
 
     # Apply theme if specified
     if theme is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+altair
+vl-convert-python
+matplotlib
+pandas


### PR DESCRIPTION
### **Summary of Changes 🚀**  

During the development of the **UpSet** visualization interface (https://labmaster.streamlit.app/~/+/venn_diagram#upset-plot), I improved the **color management system** to enhance user experience.  

#### **🔹 Initial Issue**  
- Colors had to be defined **exclusively** in **hexadecimal format** (`#RRGGBB`).  
- This was inconvenient, especially when designing a **user-friendly interface** where users should be able to change colors easily.  

#### **🔹 Implemented Solution**  
- Added **support for Matplotlib color names** 🎨 (e.g., `"red"`, `"blue"`, `"goldenrod"`).  
- Users can now **enter a color name directly** instead of a hex code.  
- **Matplotlib is required** (`pip install matplotlib`).  
- For `color_range`, if a Matplotlib colormap (e.g., `"viridis"`, `"plasma"`) is provided, the **correct hexadecimal values are automatically computed**.  

#### **🔹 Error Handling & Fallback**  
- If an invalid color name is entered, **default colors are used** to prevent errors.  
- In case of an invalid input, a **list of available colors is printed** to guide the user.  
- Added these lists directly into `altair_upset/upset.py`.  

---

### **🎯 Benefits**  
✅ **Easier customization**: No need to manually find hex codes.  
✅ **Better UX**: Users can pick colors intuitively.  
✅ **Robust fallback**: Prevents crashes due to incorrect input.  

With these improvements, **UpSet** visualizations are now **more user-friendly and customizable**! 🎨✨

PS: there are also the commits and push of the PR #6 